### PR TITLE
v2.0.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,12 @@ Homebridge plugin to control OpenSprinkler with HomeKit via the OpenSprinkler AP
 
 </span>
 
+## Support
+
+This plugin only supports OpenSprinkler firmware version 2.1.6 and above. If you aren't on one of these
+firmware versions, you'll need to upgrade. If you're on one of the supported firmware versions and
+the plugin still doesn't work, please open an issue on Github.
+
 ## Installation
 
 Install via the Homebridge UI for the easiest experience. Search under the "Plugins" tab for `homebridge-opensprinkler-api` and click "Install".

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "homebridge-opensprinkler-api",
-  "version": "2.0.3-beta.1",
+  "version": "2.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "homebridge-opensprinkler-api",
-      "version": "2.0.3-beta.1",
+      "version": "2.0.3",
       "license": "Apache-2.0",
       "dependencies": {
         "md5": "^2.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "homebridge-opensprinkler-api",
-  "version": "2.0.2",
+  "version": "2.0.3-beta.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "homebridge-opensprinkler-api",
-      "version": "2.0.2",
+      "version": "2.0.3-beta.1",
       "license": "Apache-2.0",
       "dependencies": {
         "md5": "^2.3.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "displayName": "Homebridge OpenSprinkler API",
   "name": "homebridge-opensprinkler-api",
-  "version": "2.0.3-beta.1",
+  "version": "2.0.3",
   "description": "A Homebridge plugin to control OpenSprinkler with HomeKit.",
   "license": "Apache-2.0",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "displayName": "Homebridge OpenSprinkler API",
   "name": "homebridge-opensprinkler-api",
-  "version": "2.0.2",
+  "version": "2.0.3-beta.1",
   "description": "A Homebridge plugin to control OpenSprinkler with HomeKit.",
   "license": "Apache-2.0",
   "type": "module",

--- a/src/__tests__/openSprinklerApi.test.ts
+++ b/src/__tests__/openSprinklerApi.test.ts
@@ -281,4 +281,22 @@ describe('OpenSprinklerApi', () => {
       }
     });
   });
+
+  describe('checkSupport', () => {
+    test('should return true if the firmware version is greater than 2.1.5', async () => {
+      setup({ ok: true, json: () => ({ fwv: 216 }) });
+
+      const result = await api.checkSupport();
+
+      expect(result).toBe(true);
+    });
+
+    test('should return false if the firmware version is less than 2.1.6', async () => {
+      setup({ ok: true, json: () => ({ fwv: 215 }) });
+
+      const result = await api.checkSupport();
+
+      expect(result).toBe(false);
+    });
+  })
 });

--- a/src/openSprinklerApi.ts
+++ b/src/openSprinklerApi.ts
@@ -11,6 +11,14 @@ export class OpenSprinklerApi {
     this.baseUrl = `http://${host}`;
   }
 
+  // This will be used to determine if the firmware version is supported
+  async checkSupport() {
+    const { fwv } = await this.makeRequest('jo');
+
+    // This plugin supports version 2.1.6 and above. So if it's 2.1.5 or lower, we'll indicate that.
+    return fwv > 215 ? true : false;
+  }
+
   async getInfo() {
     const { options: { fwv, hwv }, settings: { mac, loc } } = await this.makeRequest('ja');
     const firmwareVersion = fwv.toString();

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -44,6 +44,12 @@ export class OpenSprinklerPlatform implements DynamicPlatformPlugin {
 
   async setUp() {
     try {
+      const isSupportedFirmware = await this.openSprinklerApi.checkSupport();
+
+      if (!isSupportedFirmware) {
+        throw new Error('This plugin only supports firmware version 2.1.6 and above. Please update your firmware and try again.');
+      }
+
       const { firmwareVersion, hardwareVersion, macAddress, systemLocation } = await this.openSprinklerApi.getInfo();
 
       // When the location isn't specified, the value is set to "''"


### PR DESCRIPTION
Making it so a warning is given and the plugin doesn't load if the OpenSprinkler firmware version is lower than 2.1.6.